### PR TITLE
Fix compiler warnings and an error

### DIFF
--- a/src/gc_internal.h
+++ b/src/gc_internal.h
@@ -1,6 +1,7 @@
 #ifndef GC_INTERNAL_H
 #define GC_INTERNAL_H
 
+#include <stdint.h>
 #include <stdbool.h>
 #include <stdlib.h>
 #include "gc.h"


### PR DESCRIPTION
Add the header file of stdint.h for fix the compiler error when using data type intptr_t or uintptr_t.