### PR TITLE
Fix bool initialization

### DIFF
--- a/src/alloc.c
+++ b/src/alloc.c
@@ -9,7 +9,7 @@ void *gc_alloc(size_t size)
     gc_ptr_t p = (gc_ptr_t){
         .start = ptr,
         .size = size,
-        .marked = 3,
+        .marked = true,
     };
     if (__gc_object.min > ptr)
         __gc_object.min = ptr;


### PR DESCRIPTION
Although there's no any warnings while compiling, we should use `true`
to initialize bool variable to match proper semantics.